### PR TITLE
fix: stop site crashes when using other languages

### DIFF
--- a/src/components/convenes/import-tutorial.tsx
+++ b/src/components/convenes/import-tutorial.tsx
@@ -51,7 +51,7 @@ export function ImportTutorial({ redirectToHistory }: Props) {
   const isValidGamePath = gamePathRegex.test(gamePath);
   // matches valid Convene History API URLs
   const conveneHistoryUrlRegex =
-    /^https:\/\/aki-gm-resources-oversea\.aki-game\.net\/aki\/gacha\/index\.html\#\/record\?(?=.*\bplayer_id=\w+\b)(?=.*\blang=\w+\b)(?=.*\brecord_id=\w+\b)(?=.*\bsvr_id=\w+\b).*$/;
+    /^https:\/\/aki-gm-resources-oversea\.aki-game\.net\/aki\/gacha\/index\.html\#\/record\?(?=.*\bplayer_id=\w+\b)(?=.*\brecord_id=\w+\b)(?=.*\bsvr_id=\w+\b).*$/;
   const isValidConveneHistoryUrl =
     conveneHistoryUrl !== "" && conveneHistoryUrlRegex.test(conveneHistoryUrl);
 

--- a/src/lib/extractGachaRecordQueryArgs.ts
+++ b/src/lib/extractGachaRecordQueryArgs.ts
@@ -3,6 +3,7 @@ import {
   GachaRecordQueryArgs,
   GachaRecordQueryArgsSchema,
 } from "@/types/GachaRecordQuery";
+import { LanguageCode } from "@/types/LangaugeCode";
 
 /**
  * Extracts the query string parameters from a Convene History URL.
@@ -13,7 +14,6 @@ import {
  *
  * // Outputs:
  * {
- *   cardPoolId: "5c13a63f85465e9fcc0f24d6efb15083",
  *   languageCode: "en",
  *   playerId: "900643805",
  *   recordId: "e005b89e3a163ff66d2bbc9263b9a434",

--- a/src/lib/extractGachaRecordQueryArgs.ts
+++ b/src/lib/extractGachaRecordQueryArgs.ts
@@ -3,7 +3,6 @@ import {
   GachaRecordQueryArgs,
   GachaRecordQueryArgsSchema,
 } from "@/types/GachaRecordQuery";
-import { LanguageCode } from "@/types/LangaugeCode";
 
 /**
  * Extracts the query string parameters from a Convene History URL.

--- a/src/services/fetchGachaRecordByCardPoolType.ts
+++ b/src/services/fetchGachaRecordByCardPoolType.ts
@@ -4,7 +4,6 @@ import {
   GachaRecordQueryArgs,
 } from "@/types/GachaRecordQuery";
 import axios from "axios";
-import { LanguageCode } from "@/types/LangaugeCode";
 
 /**
  * Fetches the gacha records of a cardPoolType given the `GachaRecordQueryArgs` fetched from a user's Convene History URL fetched from the game logs.

--- a/src/services/fetchGachaRecordByCardPoolType.ts
+++ b/src/services/fetchGachaRecordByCardPoolType.ts
@@ -4,6 +4,7 @@ import {
   GachaRecordQueryArgs,
 } from "@/types/GachaRecordQuery";
 import axios from "axios";
+import { LanguageCode } from "@/types/LangaugeCode";
 
 /**
  * Fetches the gacha records of a cardPoolType given the `GachaRecordQueryArgs` fetched from a user's Convene History URL fetched from the game logs.

--- a/src/types/GachaRecordQuery.ts
+++ b/src/types/GachaRecordQuery.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { LanguageCode } from "./LangaugeCode";
+import { LanguageCodeEnumSchema } from "./LangaugeCode";
 
 export const ResourceType = {
   Resonators: "Resonators",
@@ -9,7 +9,7 @@ export const ResourceTypeEnumSchema = z.nativeEnum(ResourceType);
 export type ResourceTypeEnum = z.infer<typeof ResourceTypeEnumSchema>;
 
 export const GachaRecordQueryArgsSchema = z.object({
-  languageCode: z.nativeEnum(LanguageCode),
+  languageCode: LanguageCodeEnumSchema,
   playerId: z.string(),
   recordId: z.string(),
   serverId: z.string(),

--- a/src/types/LangaugeCode.ts
+++ b/src/types/LangaugeCode.ts
@@ -3,5 +3,10 @@ import { z } from "zod";
 export const LanguageCode = {
   en: "en",
 } as const;
-export const LanguageCodeEnumSchema = z.nativeEnum(LanguageCode);
+
+// TODO: Site will always use "en" temporarily to prevent site crashes, more flexible language support is needed
+export const LanguageCodeEnumSchema = z.preprocess(
+  (_) => LanguageCode.en,
+  z.nativeEnum(LanguageCode).default(LanguageCode.en),
+);
 export type LangaugeCodeEnum = z.infer<typeof LanguageCodeEnumSchema>;


### PR DESCRIPTION
## Problem Context

Using values that aren't "en" inside the Convene History URL makes the site crash. This is because the `ConveneHistoryURLParams.ts` schema used to validate a Convene History URL inputted by the user only accepts `"en"` as a valid value.

```ts
// LanguageCode.ts
export const LanguageCode = {
  en: "en",
} as const;
```

See this issue for more context: https://github.com/Luzefiru/wuwatracker/issues/35

## Solution

To fix this, I used [zod's preprocess feature](https://zod.dev/?id=preprocess) to add a hardcoded `"en"` value to use it as a basis for queries.

```ts
// TODO: Site will always use "en" temporarily to prevent site crashes, more flexible language support is needed
export const LanguageCodeEnumSchema = z.preprocess(
  (_) => LanguageCode.en,
  z.nativeEnum(LanguageCode).default(LanguageCode.en),
);
```

This temporary solution will allow people that use other in-game languages to use our website, but the results will be in English. Our site currently uses the English names for comparison of gacha items to determine their rarity and image asset to display.

### For the Future

It would be nice to dynamically determine these values, by using the `resourceId` of a wish entry:

```diff
{
      "cardPoolType": "6",
+    "resourceId": 21040013,
      "qualityLevel": 3,
      "resourceType": "Weapons",
      "name": "Gauntlets of Night",
      "count": 1,
      "time": "2024-06-01 23:57:15"
},
```

## Testing

Tested this with the following Convene History URL's for the import page:
- With `lang=de`
  - `https://aki-gm-resources-oversea.aki-game.net/aki/gacha/index.html#/record?svr_id=10cd7254d57e58ae560b15d51e34b4c8&player_id=900330507&lang=de&gacha_id=100001&gacha_type=1&svr_area=global&record_id=cd865bc0d9dcdb3467c0cc53ffcf7e78&resources_id=5c13a63f85465e9fcc0f24d6efb15083`
- With `lang=en`
  - `https://aki-gm-resources-oversea.aki-game.net/aki/gacha/index.html#/record?svr_id=10cd7254d57e58ae560b15d51e34b4c8&player_id=900330507&lang=en&gacha_id=100001&gacha_type=1&svr_area=global&record_id=cd865bc0d9dcdb3467c0cc53ffcf7e78&resources_id=5c13a63f85465e9fcc0f24d6efb15083`
- With no `lang` query argument
  - `https://aki-gm-resources-oversea.aki-game.net/aki/gacha/index.html#/record?svr_id=10cd7254d57e58ae560b15d51e34b4c8&player_id=900330507&gacha_id=100001&gacha_type=1&svr_area=global&record_id=cd865bc0d9dcdb3467c0cc53ffcf7e78&resources_id=5c13a63f85465e9fcc0f24d6efb15083`

## Closing Issues

Resolves #35.
