### PR TITLE
fix: add warning tip for those who edited Engine.ini

### DIFF
--- a/src/components/convenes/import-tutorial.tsx
+++ b/src/components/convenes/import-tutorial.tsx
@@ -98,6 +98,16 @@ export function ImportTutorial({ redirectToHistory }: Props) {
                   onBlur={(e) => setGamePath(e.target.value)}
                 />
               </div>
+              <ul className="flex flex-col gap-2 md:ps-8 md:list-disc mt-2 mb-4">
+                <li>
+                  <p className="text-sm font-normal text-muted-foreground">
+                    Warning: If you edited your <code>Engine.ini</code> file to
+                    disable logs, you&apos;ll have to re-enable them before
+                    opening your convene history, otherwise the script
+                    won&apos;t work.
+                  </p>
+                </li>
+              </ul>
             </li>
             <li className="mb-10 ms-8">
               <span className="absolute -start-4 bg-accent rounded-full w-8 h-8 p-3 flex justify-center items-center">
@@ -144,17 +154,21 @@ export function ImportTutorial({ redirectToHistory }: Props) {
                   </TooltipContent>
                 </Tooltip>
               </div>
-              <p className="my-4 text-sm font-normal text-muted-foreground">
-                Note: The script does not edit your files, it simply extracts
-                the URL from your logs. You can view the script{" "}
-                <Link
-                  className="text-yellow-500 hover:text-yellow-600"
-                  href="https://gist.github.com/Luzefiru/19c0759bea1b9e7ef480bb39303b3f6c"
-                >
-                  here
-                </Link>
-                .
-              </p>
+              <ul className="flex flex-col gap-2 md:ps-8 md:list-disc mt-2 mb-4">
+                <li>
+                  <p className="text-sm font-normal text-muted-foreground">
+                    Note: The script does not edit your files, it simply
+                    extracts the URL from your logs. You can view the script{" "}
+                    <Link
+                      className="text-yellow-500 hover:text-yellow-600"
+                      href="https://gist.github.com/Luzefiru/19c0759bea1b9e7ef480bb39303b3f6c"
+                    >
+                      here
+                    </Link>
+                    .
+                  </p>
+                </li>
+              </ul>
             </li>
             <li className="mb-10 ms-8">
               <span className="absolute -start-4 bg-accent rounded-full w-8 h-8 p-3 flex justify-center items-center">


### PR DESCRIPTION
## Problem Context

People that disable their logs inside their `Wuthering Waves Game\Client\Saved\Config\WindowsNoEditor\Engine.ini` cannot fetch their Convene History URL after they open their in-game history. To fix that, they have to re-enable it by manually editing the file by themselves.

See #30.

## Solution

I added & styled a tooltip under the first step:

![image](https://github.com/Luzefiru/wuwatracker/assets/105530193/9b1d0710-48e0-4728-8f4c-d6a08b34376b)

## Testing

Here's what it looks like on various screen sizes:

![demo](https://github.com/Luzefiru/wuwatracker/assets/105530193/09cb1275-126f-4b26-b266-20d0879cbf55)

## Closing Issues

Resolves #30.