### PR TITLE
fix: change 4* pity tracking

### DIFF
--- a/src/components/convenes/convene-avatar.tsx
+++ b/src/components/convenes/convene-avatar.tsx
@@ -25,12 +25,24 @@ export function ConveneAvatar({
   previousFourStarPullNumber,
 }: Props) {
   function getBadgeVariant(pullNumber: number) {
-    if (pullNumber >= 65) {
-      return "destructive";
-    } else if (pullNumber >= 30) {
-      return "warning";
+    const isFourStar = qualityLevel === 4 && fourStarCurrentPity === 0;
+
+    if (isFourStar) {
+      if (pullNumber >= 8) {
+        return "destructive";
+      } else if (pullNumber >= 4) {
+        return "warning";
+      } else {
+        return "success";
+      }
     } else {
-      return "success";
+      if (pullNumber >= 65) {
+        return "destructive";
+      } else if (pullNumber >= 40){
+        return "warning";
+      } else {
+        return "success";
+      }
     }
   }
 
@@ -38,6 +50,7 @@ export function ConveneAvatar({
     qualityLevel,
     fourStarCurrentPity,
     pullNumber,
+    previousFourStarPullNumber,
     previousFiveStarPullNumber,
   );
 

--- a/src/components/convenes/pull-history.tsx
+++ b/src/components/convenes/pull-history.tsx
@@ -4,7 +4,6 @@ import React from "react";
 import InfiniteScroll from "../ui/scroll-area";
 import getPullNumber from "@/lib/getPullNumber";
 
-import { useState } from "react";
 import { BannerStats } from "@/types/BannerStats";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -62,6 +61,7 @@ export function PullHistory({ stats }: Props) {
                             item.qualityLevel,
                             item.fourStarCurrentPity,
                             item.pullNumber,
+                            item.previousFourStarPullNumber,
                             item.previousFiveStarPullNumber,
                           )}
                         </TableCell>

--- a/src/lib/getPullNumber.ts
+++ b/src/lib/getPullNumber.ts
@@ -4,6 +4,7 @@
  * @param qualityLevel - the rarity level of a character
  * @param fourStarCurrentPity - the current pity for four star items (out of 10)
  * @param pullNumber - the overall pull number which an item was acquired
+ * @param previousFourStarPullNumber - the last pity in which a four star item was pulled
  * @param previousFiveStarPullNumber - the last pity in which a five star item was pulled
  * @returns an integer that represents an item's current pull number within pity
  */
@@ -11,12 +12,10 @@ export default function getPullNumber(
   qualityLevel: number,
   fourStarCurrentPity: number,
   pullNumber: number,
+  previousFourStarPullNumber: number,
   previousFiveStarPullNumber: number,
 ) {
   const isFourStar = qualityLevel === 4 && fourStarCurrentPity === 0;
 
-  if (isFourStar) {
-    return pullNumber - previousFiveStarPullNumber;
-  }
-  return pullNumber - previousFiveStarPullNumber;
+  return pullNumber - (isFourStar ? previousFourStarPullNumber : previousFiveStarPullNumber);
 }


### PR DESCRIPTION
## Problem Context
Currently, 4* pity and associated displays are counting based on the last 5* pity, and not on the 4* pity itself. This has caused confusion and the general sentiment is to track the standalone 4* pity.

See #36.

## Solution
- Changes 4* pity to track solely on 4* pulls and not 5* pull pity. 
- Adjusts badge colors based on the pull number depending if the wish is a 4* or a 5*
- Small nit: removes unused import for `useState` in `pull-history.tsx`

Additional commentary: I did attempt to add more colors to the pity badges, but from inspection, it seemed like they would be quite awkward to implement without significantly adding more colors for a subtler gradient (like paimon.moe for Genshin), while remaining too cluttered/busy/distracting at the suggested 5. starrailstation for HSR also uses only three colors to distinguish between "early", "middle", and "late/pity" pulls. 

Furthermore, starrailstation seems to nudge their "middle" pulls counter to a bit of a higher number, which I am biased towards as well and adjusted in this PR. (For example, I would not view a 5* wish between 30-40 as a "middle" pull but rather an "early" pull still, whereas between 40-60 I'm more inclined to accept as a "middle" pull. For comparison, HSR's starrailstation also seems to start their "middle" pulls around 40-45 for the weapon banner, which has the same 80 counter to use as a benchmark against WuWa's banners.)

## Testing
New pulls history count: 
<img width="709" alt="image" src="https://github.com/Luzefiru/wuwatracker/assets/8635193/677430cc-a9fb-4318-ad63-97ba0b098cd5">

## Closing Issues

Closes #36.
