### PR TITLE
fix: Fix condition for tide icon

### DIFF
--- a/src/components/convenes/banner-stats-card.tsx
+++ b/src/components/convenes/banner-stats-card.tsx
@@ -97,7 +97,7 @@ export function BannerStatsCard({
                 <h1 className="text-lg">{stats ? stats.totalPulls : 0}</h1>
                 <Image
                   src={
-                    description.includes("Event")
+                    description.includes("Featured")
                       ? "/icons/radiant-tide.webp"
                       : "/icons/lustrous-tide.webp"
                   }


### PR DESCRIPTION
## Problem Context

The icon being used for amount of tides spent for each banner was wrong.

## Solution

Fix condition for using proper tide icons.

