### PR TITLE
nit: fix wording on Convene History Sync subtitle

### DIFF
--- a/i18n/messages/en.json
+++ b/i18n/messages/en.json
@@ -530,7 +530,7 @@
       "Convene History Data": "Convene History Data",
       "Import Tutorial": "Import Tutorial",
       "Go to Import Tutorial": "Go to Import Tutorial",
-      "description": "Export or change your Convene History URL here.",
+      "description": "Edit your Convene History URL and export it as JSON.",
       "Your Convene History URL": "Your Convene History URL",
       "Download Your History": "Download Your History",
       "Delete Browser Saved Data": "Delete Browser Saved Data",


### PR DESCRIPTION
## Problem Context

![image](https://github.com/user-attachments/assets/7ea9aaaf-3f96-47dd-b1da-18464ad389c7)

Translators have been complaining that this subtitle is confusing and leads to issues in translation.

## Solution

Changed it to make it more explicit
