### PR TITLE
feat: added groups to 7 day login event.

### DIFF
--- a/events.ts
+++ b/events.ts
@@ -21,6 +21,7 @@ export const EVENT_GROUP = {
   ILLUSIVE_REALM: 1,
   TOWER_OF_ADVERSITY: 2,
   DOUBLE_DROPS: 3,
+  SEVEN_DAY_LOGIN: 4,
 };
 
 /**
@@ -174,6 +175,7 @@ const rawEvents: { banners: Event[]; activities: Event[] } = {
       url: "https://wutheringwaves.kurogames.com/en/main/news/detail/975",
       reliability: "Official",
       isGlobal: true,
+      group: EVENT_GROUP.SEVEN_DAY_LOGIN,
     },
     {
       name: "Depths of Illusive Realm: Dreams Ablaze in Darkness",
@@ -217,6 +219,7 @@ const rawEvents: { banners: Event[]; activities: Event[] } = {
       startDate: "2024-08-15 13:00",
       isGlobal: true,
       color: "#a1ccfa",
+      group: EVENT_GROUP.SEVEN_DAY_LOGIN,
     },
     {
       name: "Converging Paths",


### PR DESCRIPTION
## Problem Context

With more and more events happening, the timeline on the timeline page gets increasingly taller

## Solution

This PR allows grouping together the "log in for 7 days and get rewards" events that they are adding each patch into a single group, therefore making the timeline slightly more compact.

## Testing

Before: 
![image](https://github.com/user-attachments/assets/5b469ebc-fd62-4a90-a4d2-0487544ce763)


After: ![image](https://github.com/user-attachments/assets/18b82ef1-ef20-4458-a7a4-24d455098036)


